### PR TITLE
Http uploads

### DIFF
--- a/src/preferences.py
+++ b/src/preferences.py
@@ -85,6 +85,10 @@ class PreferencesDialog:
                 self.builder.get_object(field).set_sensitive(True)
             for field in server_port_dir_url:
                 self.builder.get_object(field).set_sensitive(False)
+	elif proto in ['HTTP']:
+		for field in all_fields:
+			self.builder.get_object(field).set_sensitive(False)
+		self.builder.get_object('url').set_sensitive(True)
         else:
             for field in all_fields:
                 self.builder.get_object(field).set_sensitive(False)
@@ -93,6 +97,8 @@ class PreferencesDialog:
             self.builder.get_object('port').set_value(21)
         elif proto == 'SSH':
             self.builder.get_object('port').set_value(22)
+	elif proto == 'HTTP':
+	    self.builder.get_object('port').set_value(80)
 
     def on_dialog_response(self, widget, data=None):
         if data != 1:

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -79,6 +79,31 @@ class OmploaderUploader:
 		m = re.findall("v\w+", self.response)
 		self.mapping['original_image'] = "http://ompldr.org/%s" % m[2]
 
+
+class HTTPUploader:
+	def __init__(self):
+		self.response = ''
+
+	def curl_response(self, buf):
+		self.response = self.response + buf
+
+	def upload(self, image, url):
+		c = pycurl.Curl()
+		values = [	('file', (c.FORM_FILE, image))]
+		c.setopt(c.URL, url)
+		c.setopt(c.HTTPPOST, values)
+		c.setopt(c.WRITEFUNCTION, self.curl_response)
+		
+		try:
+			c.perform()
+		except pycurl.error:
+			c.close()
+			return False, "There was an error during HTTP upload."
+		
+		c.close()
+
+		return True, self.response
+
 def get_proto_list():
 	return PROTO_LIST
 
@@ -100,16 +125,17 @@ def upload_file_ftp(f, hostname, port, username, password, directory, url):
 	return True, None
 
 def upload_file_http(f, url):
-	c = pycurl.Curl()
-	values = [	('file', (c.FORM_FILE, image))]
-	c.setopt(c.URL, url)
-	c.setopt(c.HTTPPOST, values)
-	c.setopt(c.WRITEFUNCTION, self.curl_response)
+	i = HTTPUploader()
+	
+	status, data = i.upload(f, url)	
 
-	c.perform()
-	c.close()
+	if status:
+		obj = {}
+		obj['original_image'] = data;
 
-	return True, None
+		return True, obj
+	else:
+		return False, data
 
 def upload_file_sftp(f, hostname, port, username, password, directory, url):
     try:
@@ -182,8 +208,8 @@ def upload_file(image, existing_file=False):
                     config.get('Upload', 'url'),
                     )
     elif proto == 'HTTP':
-	liblookit.show_notification('Lookit', 'Upload image to {0}...'.format(config.get('Upload', 'hostname')))
-	success, data = upload_file_http(image, config.get('Upload', hostname))
+	liblookit.show_notification('Lookit', 'Upload image to {0}...'.format(config.get('Upload', 'URL')))
+	success, data = upload_file_http(image, config.get('Upload', 'URL'))
     elif proto == 'FTP':
         liblookit.show_notification('Lookit', 'Uploading image to {0}...'.format(config.get('Upload', 'hostname')))
         success, data = upload_file_ftp(image,

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -41,8 +41,10 @@ try:
 	import pycurl
 	import re
 	PROTO_LIST.append('Omploader')
+	PROTO_LIST.append('HTTP')
 except ImportError:
 	print 'Omploader support not available'
+	print 'HTTP support not available'	
 
 try:
     import cloud
@@ -94,6 +96,18 @@ def upload_file_ftp(f, hostname, port, username, password, directory, url):
 		return False, 'Error occured during FTP upload'
 
 	i.close()
+
+	return True, None
+
+def upload_file_http(f, url):
+	c = pycurl.Curl()
+	values = [	('file', (c.FORM_FILE, image))]
+	c.setopt(c.URL, url)
+	c.setopt(c.HTTPPOST, values)
+	c.setopt(c.WRITEFUNCTION, self.curl_response)
+
+	c.perform()
+	c.close()
 
 	return True, None
 
@@ -167,6 +181,9 @@ def upload_file(image, existing_file=False):
                     config.get('Upload', 'directory'),
                     config.get('Upload', 'url'),
                     )
+    elif proto == 'HTTP':
+	liblookit.show_notification('Lookit', 'Upload image to {0}...'.format(config.get('Upload', 'hostname')))
+	success, data = upload_file_http(image, config.get('Upload', hostname))
     elif proto == 'FTP':
         liblookit.show_notification('Lookit', 'Uploading image to {0}...'.format(config.get('Upload', 'hostname')))
         success, data = upload_file_ftp(image,


### PR DESCRIPTION
Puts an HTTP option into the preferences page, so users can upload images to a custom web page - whether that be a homebrew or an API somewhere.

I also added support that the cURL response can contain a URL to the uploaded image.  It's a pretty simple setup right now, but I think to make it robust would require a lot of user interaction.  You can extend/subtract from this as you see fit.
