### PR TITLE
More public key stuff

### DIFF
--- a/src/data/preferences.xml
+++ b/src/data/preferences.xml
@@ -385,7 +385,7 @@
                   <object class="GtkTable" id="table1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="n_rows">6</property>
+                    <property name="n_rows">7</property>
                     <property name="n_columns">2</property>
                     <child>
                       <object class="GtkLabel" id="label5">
@@ -439,8 +439,8 @@
                         <property name="label" translatable="yes">Directory:</property>
                       </object>
                       <packing>
-                        <property name="top_attach">4</property>
-                        <property name="bottom_attach">5</property>
+                        <property name="top_attach">5</property>
+                        <property name="bottom_attach">6</property>
                       </packing>
                     </child>
                     <child>
@@ -491,8 +491,8 @@
                       <packing>
                         <property name="left_attach">1</property>
                         <property name="right_attach">2</property>
-                        <property name="top_attach">4</property>
-                        <property name="bottom_attach">5</property>
+                        <property name="top_attach">5</property>
+                        <property name="bottom_attach">6</property>
                       </packing>
                     </child>
                     <child>
@@ -523,8 +523,8 @@
                         <property name="label" translatable="yes">URL:</property>
                       </object>
                       <packing>
-                        <property name="top_attach">5</property>
-                        <property name="bottom_attach">6</property>
+                        <property name="top_attach">6</property>
+                        <property name="bottom_attach">7</property>
                       </packing>
                     </child>
                     <child>
@@ -542,8 +542,8 @@
                       <packing>
                         <property name="left_attach">1</property>
                         <property name="right_attach">2</property>
-                        <property name="top_attach">5</property>
-                        <property name="bottom_attach">6</property>
+                        <property name="top_attach">6</property>
+                        <property name="bottom_attach">7</property>
                       </packing>
                     </child>
                     <child>
@@ -564,6 +564,35 @@
                         <property name="right_attach">2</property>
                         <property name="top_attach">1</property>
                         <property name="bottom_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label16">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">SSH Key File:</property>
+                      </object>
+                      <packing>
+                        <property name="top_attach">4</property>
+                        <property name="bottom_attach">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="ssh_key_file">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="invisible_char">•</property>
+                        <property name="primary_icon_activatable">False</property>
+                        <property name="secondary_icon_activatable">False</property>
+                        <property name="primary_icon_sensitive">True</property>
+                        <property name="secondary_icon_sensitive">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="right_attach">2</property>
+                        <property name="top_attach">4</property>
+                        <property name="bottom_attach">5</property>
                       </packing>
                     </child>
                   </object>

--- a/src/lookitconfig.py
+++ b/src/lookitconfig.py
@@ -41,6 +41,7 @@ DEFAULTS = {'General': {'shortenurl': False,
                         'hostname': '',
                         'port': 0,
                         'username': '',
+                        'ssh_key_file': '',
                         'directory': '',
                         'url': 'http://'}
 }

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -20,6 +20,7 @@ WIDGETS = ( (bool, 'trash', 'General', 'trash'),
             (str, 'username', 'Upload', 'username'),
             (str, 'password', 'Upload', 'password'),
             (int, 'port', 'Upload', 'port'),
+            (str, 'ssh_key_file', 'Upload', 'ssh_key_file'),
             (str, 'directory', 'Upload', 'directory'),
             (str, 'url', 'Upload', 'url'),
             (None, 'combobox', 'Upload', 'type'),
@@ -77,6 +78,9 @@ class PreferencesDialog:
         server_port_dir_url = ('server', 'port', 'directory', 'url')
         all_fields = user_pass + server_port_dir_url
 
+        # Set to False as only used for SSH.
+        self.builder.get_object('ssh_key_file').set_sensitive(False)
+
         if proto in ['FTP', 'SSH']:
             for field in all_fields:
                 self.builder.get_object(field).set_sensitive(True)
@@ -96,6 +100,7 @@ class PreferencesDialog:
         if proto == 'FTP':
             self.builder.get_object('port').set_value(21)
         elif proto == 'SSH':
+            self.builder.get_object('ssh_key_file').set_sensitive(True)
             self.builder.get_object('port').set_value(22)
 	elif proto == 'HTTP':
 	    self.builder.get_object('port').set_value(80)

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -137,14 +137,21 @@ def upload_file_http(f, url):
 	else:
 		return False, data
 
-def upload_file_sftp(f, hostname, port, username, password, directory, url):
+def upload_file_sftp(f, hostname, port, username, password, ssh_key_file, directory, url):
     try:
         # Debug info.
         #paramiko.util.log_to_file('paramiko.log')
 
+        # Paramiko needs 'None' for these two, probably a bad place to put them
+        # but I'm lazy.
+        if password == '':
+            password = None
+        if ssh_key_file == '':
+            ssh_key_file = None
+
         client = paramiko.SSHClient()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        client.connect(hostname, port, username, password)
+        client.connect(hostname, port, username, password, key_filename=ssh_key_file)
         sftp = client.open_sftp()
         sftp.chdir(directory)
         sftp.put(f, os.path.basename(f))
@@ -208,6 +215,7 @@ def upload_file(image, existing_file=False):
                     int(config.get('Upload', 'port')),
                     config.get('Upload', 'username'),
                     config.get('Upload', 'password'),
+                    config.get('Upload', 'ssh_key_file'),
                     config.get('Upload', 'directory'),
                     config.get('Upload', 'url'),
                     )


### PR DESCRIPTION
Added SSH key file field in Preferences - this will be used by Paramiko
as well as searching `~/.ssh`.

The password field is ignored if an SSH key file is specified, unless
that key file does not correspond with the server, in which case
password authentication will be attempted.

I tried using the password field to unlock a locked private key, but
with no luck; so that's an area for improvement in the future.

If the SSH key file field is left empty, Paramiko will still look in
`~/.ssh`, so it is purely used for specifying a key file outside that
directory.
